### PR TITLE
Enable swap to avoid out of memory.

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -4,6 +4,8 @@
 
 app = "exit-node"
 primary_region = "sjc"
+swap_size_mb = 2048
+
 kill_signal = "SIGINT"
 kill_timeout = 5
 processes = []


### PR DESCRIPTION
App used >256MB ram at startup and crashed due to out of memory.

Enable swap to avoid this.